### PR TITLE
show init usage when used with positional arguments

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,12 +74,25 @@ if (positionals.length == 2) {
             "single-d1-database",
             "single-queue",
         ];
-        const panels = ["workers", "durables", "buckets", "domains", "queues", "d1", "kv"];
+
+        const panels = [
+            "workers",
+            "durables",
+            "buckets",
+            "domains",
+            "queues",
+            "d1",
+            "kv",
+        ];
+
         const renderer = useRenderer();
         const [view, setView] = useState<string>("home");
         const [workers, setWorkers] = useState<Script[]>([]);
         const [durableObjects, setDurableObjects] = useState<
-            { namespace: string; objects: DurableObject[] | undefined }[]
+            {
+                namespace: string;
+                objects: DurableObject[] | undefined;
+            }[]
         >([]);
         const [r2Buckets, setR2Buckets] = useState<Bucket[]>([]);
         const [domains, setDomains] = useState<Domain[]>([]);
@@ -449,7 +462,10 @@ if (positionals.length == 2) {
                 const response = await client.workers.observability.telemetry.query({
                     account_id: config.accountId,
                     queryId: "", // Empty string to satisfy SDK validation - API will use parameters instead
-                    timeframe: { from: yesterday, to: now },
+                    timeframe: {
+                        from: yesterday,
+                        to: now,
+                    },
                     parameters: {
                         limit: 100,
                     },


### PR DESCRIPTION
When passing arguments to init, it just fails silently

Sorry about the formatting change, didn't notice 🤦‍♂️

## Before
<img width="942" height="148" alt="CleanShot 2025-11-13 at 10 36 45@2x" src="https://github.com/user-attachments/assets/2c19d5d2-d3c5-4663-b320-9e1b23c1e9fd" />

## After
<img width="1306" height="184" alt="CleanShot 2025-11-13 at 10 38 51@2x" src="https://github.com/user-attachments/assets/c9edbe3f-504c-4821-8193-960d3123b826" />
